### PR TITLE
Add additional issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/android-studio-and-gradle-issues.md
+++ b/.github/ISSUE_TEMPLATE/android-studio-and-gradle-issues.md
@@ -1,0 +1,10 @@
+---
+name: Android Studio and Gradle issues
+about: Issues related to Android Studio or the gradle plugin
+title: NOT AN NDK BUG! READ THE TEMPLATE AND DO NOT FILE HERE!
+labels: studio
+assignees: ''
+
+---
+
+This is the wrong bug tracker. Go to https://developer.android.com/studio/report-bugs and follow the instructions for filing an Android Studio bug.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,13 @@
+---
+name: Bug report
+about: Bugs related to the NDK itself. ndk-build, compiler, CMake toolchain file,
+  sysroot, etc.
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
 **Note**: Bugs against Android Studio or Gradle should be filed at
 http://b.android.com, not here.
 

--- a/.github/ISSUE_TEMPLATE/documentation-bug.md
+++ b/.github/ISSUE_TEMPLATE/documentation-bug.md
@@ -1,0 +1,16 @@
+---
+name: Documentation bug
+about: An issue with NDK documentation
+title: "[DOC]"
+labels: docs
+assignees: ''
+
+---
+
+**Note:** The NDK docs reside under https://developer.android.com/ndk/. If the bug you are reporting belongs to a different section of the site, this is the wrong bug tracker. See http://b.android.com.
+
+**URL**
+URL to the incorrect documentation (if the problem is that there is no documentation and it belongs on a new page, say so).
+
+**Problem**
+What's wrong? Does something need clarification/expansion? Is there a typo?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FR]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
GitHub now supports multiple issue templates:
https://blog.github.com/2018-05-02-issue-template-improvements/.

This patch adds templates for the most common cases.